### PR TITLE
Enhance Player Hiding Functionality with Alias Commands, and Optimizations

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -131,7 +131,7 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
 
                 var pawn = target.PlayerPawn.Value!;
 
-                if ((LifeState_t)pawn.LifeState != LifeState_t.LIFE_ALIVE && Config.HideDead)
+                if ((LifeState_t)pawn.LifeState != LifeState_t.LIFE_ALIVE)
                 {
                     info.m_pTransmitEntity.Clear((int)pawn.Index);
                     continue;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -10,7 +10,7 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
 {
     public override string ModuleName => "HidePlayers";
     public override string ModuleAuthor => "xstage";
-    public override string ModuleVersion => "1.1.0";
+    public override string ModuleVersion => "1.1.1";
     public override string ModuleDescription => "Plugin uses code borrowed from CS2Fixes / cs2kz-metamod / hl2sdk";
 
     public PluginConfig Config { get; set; } = new();

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -10,7 +10,7 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
 {
     public override string ModuleName => "HidePlayers";
     public override string ModuleAuthor => "xstage";
-    public override string ModuleVersion => "1.0.4";
+    public override string ModuleVersion => "1.1.0";
     public override string ModuleDescription => "Plugin uses code borrowed from CS2Fixes / cs2kz-metamod / hl2sdk";
 
     public PluginConfig Config { get; set; } = new();
@@ -21,6 +21,16 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
 
     private static readonly MemoryFunctionVoid<nint, nint, int, nint, nint, nint, int, bool> CheckTransmit = new(GameData.GetSignature("CheckTransmit"));
     private static readonly MemoryFunctionVoid<CCSPlayerPawn, CSPlayerState> StateTransition = new(GameData.GetSignature("StateTransition"));
+    
+    private static int _checkTransmitPlayerSlotCache = GameData.GetOffset("CheckTransmitPlayerSlot");
+
+    public enum HideMode {
+        HIDE_ALL,
+        HIDE_TEAM,
+        HIDE_ENEMY
+    }
+    
+    private HideMode _hideMode = HideMode.HIDE_ALL;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct CCheckTransmitInfo
@@ -68,10 +78,12 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
             return HookResult.Continue;
         });
 
-        AddCommand(Config.Command, "Hide players models", (player, info) =>
-        {
-            player?.PrintToChat(Localizer["Player.Hide", Localizer["Plugin.Tag"], (_hide[player.Index] ^= true) ? Localizer["Plugin.Enable"] : Localizer["Plugin.Disable"]]);
-        });
+        foreach (var cmd in Config.Command.Split(",")) {
+            AddCommand(Config.Command, "Hide players models", (player, info) =>
+            {
+                player?.PrintToChat(Localizer["Player.Hide", Localizer["Plugin.Tag"], Localizer[(_hide[player.Index] ^= true) ? "Plugin.Enable" : "Plugin.Disable"]]);
+            });
+        }
     }
 
     public override void Unload(bool hotReload)
@@ -95,10 +107,13 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
         nint* ppInfoList = (nint*)hook.GetParam<nint>(1);
         int infoCount = hook.GetParam<int>(2);
 
+        var candidates =
+            Utilities.GetPlayers().Where(p => !p.IsHLTV).ToList();
+
         for (int i = 0; i < infoCount; i++)
         {
             nint pInfo = ppInfoList[i];
-            byte slot = *(byte*)(pInfo + GameData.GetOffset("CheckTransmitPlayerSlot"));
+            byte slot = *(byte*)(pInfo + _checkTransmitPlayerSlotCache);
 
             var player = Utilities.GetPlayerFromSlot(slot);
             var info = Marshal.PtrToStructure<CCheckTransmitInfo>(pInfo);
@@ -106,29 +121,34 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
             if (player == null || player.Connected != PlayerConnectedState.PlayerConnected)
                 continue;
 
-            foreach (var target in Utilities.GetPlayers())
+            if (player.Pawn.Value?.As<CCSPlayerPawnBase>().PlayerState == CSPlayerState.STATE_OBSERVER_MODE)
+                continue;
+            
+            foreach (var target in candidates)
             {
-                if (target == null || target.IsHLTV || target.Slot == slot)
+                if (target.Slot == slot)
                     continue;
 
                 var pawn = target.PlayerPawn.Value!;
 
-                if (player.Pawn.Value?.As<CCSPlayerPawnBase>().PlayerState == CSPlayerState.STATE_OBSERVER_MODE)
-                    continue;
-                
-                if (pawn == null)
-                    continue;
-                
-                if ((LifeState_t)pawn.LifeState != LifeState_t.LIFE_ALIVE)
+                if ((LifeState_t)pawn.LifeState != LifeState_t.LIFE_ALIVE && Config.HideDead)
                 {
                     info.m_pTransmitEntity.Clear((int)pawn.Index);
                     continue;
                 }
 
-                if (_hide[player.Index] && (Config.Hidden.Equals("@enemy") && player.Team != target.Team || Config.Hidden.Equals("@team") && player.Team == target.Team || Config.Hidden.Equals("@all")))
-                {
-                    info.m_pTransmitEntity.Clear((int)pawn.Index);
+                switch (_hideMode) {
+                    case HideMode.HIDE_ALL when _hide[player.Index]:
+                        break;
+                    case HideMode.HIDE_TEAM when _hide[player.Index] && player.Team == target.Team:
+                        break;
+                    case HideMode.HIDE_ENEMY when _hide[player.Index] && player.Team != target.Team:
+                        break;
+                    default:
+                        continue;
                 }
+
+                info.m_pTransmitEntity.Clear((int)pawn.Index);
             }
         }
 
@@ -163,5 +183,18 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
         }
         
         Config = config;
+        
+        _hideMode = GetHideMode(Config.Hidden);
+    }
+    
+    private HideMode GetHideMode(string mode)
+    {
+        return mode switch
+        {
+            "@all" => HideMode.HIDE_ALL,
+            "@team" => HideMode.HIDE_TEAM,
+            "@enemy" => HideMode.HIDE_ENEMY,
+            _ => HideMode.HIDE_ALL
+        };
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -79,7 +79,7 @@ public sealed class Plugin : BasePlugin, IPluginConfig<PluginConfig>
         });
 
         foreach (var cmd in Config.Command.Split(",")) {
-            AddCommand(Config.Command, "Hide players models", (player, info) =>
+            AddCommand(cmd, "Hide players models", (player, info) =>
             {
                 player?.PrintToChat(Localizer["Player.Hide", Localizer["Plugin.Tag"], Localizer[(_hide[player.Index] ^= true) ? "Plugin.Enable" : "Plugin.Disable"]]);
             });

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -4,8 +4,9 @@ namespace HidePlayers;
 
 public class PluginConfig : IBasePluginConfig
 {
-    public string Command { get; set; } = "css_hidemodels";
+    public string Command { get; set; } = "css_hidemodels,css_hide";
     public string Hidden { get; set; } = "@all";
+    public bool HideDead { get; set; } = true;
 
-    public int Version { get; set; } = 1;
+    public int Version { get; set; } = 2;
 }

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -6,7 +6,6 @@ public class PluginConfig : IBasePluginConfig
 {
     public string Command { get; set; } = "css_hidemodels,css_hide";
     public string Hidden { get; set; } = "@all";
-    public bool HideDead { get; set; } = true;
 
     public int Version { get; set; } = 2;
 }


### PR DESCRIPTION
- Support for multiple command aliases, e.g., `css_hidemodels, css_hide`, allowing more flexibility for users.
- Implemented structured hide modes (`HIDE_ALL`, `HIDE_TEAM`, `HIDE_ENEMY`) for improved clarity and maintainability.
- Simplified handling of hidden entities with an enum-based approach.
- Reduced redundant player lookups by caching potential candidates.
- **Plugin.cs**: Added enums for hide modes, introduced optimized entity visibility logic, and updated `Hook_CheckTransmit`.
- Plugin version incremented to `1.1.1`, Config incremented to `2`.

#### Impact:
These enhancements improve performance, maintainability, and usability for administrators.